### PR TITLE
Add HHAST support, add error codes, refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,6 +191,39 @@
           "type": "boolean",
           "default": true,
           "description": "Start hh_client in Language Server mode. Only works for HHVM version 3.23 and above."
+        },
+        "hack.useHhast": {
+          "type": "boolean",
+          "default": false,
+          "description": "Automatically invoke HHAST"
+        },
+        "hack.hhastPath": {
+          "type": "string",
+          "default": "vendor/bin/hhast-lint",
+          "description": "Path to hhast-lint executable. Only works for HHAST 3.27.1 and above"
+        },
+        "hack.hhastArgs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [],
+          "description": "Additional arguments to pass to hhast-lint"
+        },
+        "hack.hhastRememberedWorkspaces": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string",
+            "enum": ["trusted", "untrusted"]
+          },
+          "default": {},
+          "description": "Workspaces where whether or not to use HHAST has been remembered"
+        },
+        "hack.hhastLintMode": {
+          "type": "string",
+          "enum": ["whole-project", "open-files"],
+          "default": null,
+          "description": "Whether to lint the whole project, or just open files"
         }
       }
     },

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -32,3 +32,20 @@ if (useLanguageServerConfig === undefined) {
     useLanguageServerConfig = true;
 }
 export const useLanguageServer: boolean = useLanguageServerConfig;
+
+export const useHhast: boolean = hackConfig.get('useHhast') || false;
+
+export const hhastLintMode: 'whole-project' | 'open-files' | undefined | null = hackConfig.get('hhastLintMode');
+
+export const hhastPath: string | undefined = hackConfig.get('hhastPath');
+export const hhastArgs: string[] = hackConfig.get('hhastArgs') || [];
+
+// Use the global configuration so that a project can't both provide a malicious hhast-lint executable and whitelist itself in $project/.vscode/settings.json
+const hhastRemembered: { globalValue?: { [key: string]: 'trusted' | 'untrusted' } } | undefined = hackConfig.inspect('hhastRememberedWorkspaces');
+export const hhastRememberedWorkspaces: { [key: string]: 'trusted' | 'untrusted' } = hhastRemembered ? (hhastRemembered.globalValue || {}) : {}
+
+export async function rememberHhastWorkspace(workspace: string, trust: 'trusted' | 'untrusted') {
+    let remembered = hhastRememberedWorkspaces;
+    remembered[workspace] = trust;
+    await hackConfig.update('hhastRememberedWorkspaces', remembered, vscode.ConfigurationTarget.Global);
+}

--- a/src/LSPHHASTLint.ts
+++ b/src/LSPHHASTLint.ts
@@ -1,0 +1,105 @@
+/** @file Integration with The HHAST Linter via the LSP */
+
+import * as vscode from 'vscode';
+import { LanguageClient, HandleDiagnosticsSignature } from 'vscode-languageclient/lib/main';
+import * as config from './Config';
+import * as fs from 'fs';
+
+type LintMode = 'whole-project' | 'open-files';
+type InitializationOptions = {
+  'lintMode' ?: LintMode,
+};
+
+export class LSPHHASTLint {
+  private context: vscode.ExtensionContext;
+  private hhastPath: string;
+
+  constructor(context: vscode.ExtensionContext, hhastPath: string) {
+    this.context = context;
+    this.hhastPath = hhastPath;
+  }
+
+  /** Start if HHAST support is enabled, the project uses HHAST, and the user
+   * enables HHAST support for this project.
+   */
+  public static async startIfConfiguredAndEnabled(context: vscode.ExtensionContext): Promise<void> {
+    if (!config.useHhast) {
+      return;
+    }
+    const workspace = config.workspace;
+    const usesLint: boolean = await new Promise<boolean>((resolve, _) => fs.access(workspace + '/hhast-lint.json', err => resolve(!err)));
+    if (!usesLint) {
+      return;
+    }
+
+    const rawHhastPath = config.hhastPath;
+    const hhastPath = rawHhastPath && rawHhastPath[0] !== '/'
+      ? (workspace + '/' + rawHhastPath)
+      : rawHhastPath;
+    if (!hhastPath) {
+      return;
+    }
+    const hhastExists: boolean = await new Promise<boolean>((resolve, _) => fs.access(hhastPath, err => resolve(!err)));
+    if (!hhastExists) {
+      return;
+    }
+
+    const remembered = config.hhastRememberedWorkspaces[workspace];
+    if (remembered === 'trusted') {
+      await (new LSPHHASTLint(context, hhastPath)).run();
+      return;
+    } else if (remembered === 'untrusted') {
+      return;
+    }
+
+    const result = await vscode.window.showWarningMessage(
+      "This project uses " + hhastPath + " to lint? This has the same security risks as executing any other code in the repository.",
+      {},
+      "Yes",
+      "Always",
+      "No",
+      "Never",
+    );
+    switch (result) {
+      // @ts-ignore: Fallthrough case in switch
+      case 'Always':
+        await config.rememberHhastWorkspace(workspace, 'trusted');
+      case 'Yes':
+        await (new LSPHHASTLint(context, hhastPath)).run();
+        break;
+      // @ts-ignore: Fallthrough case in switch
+      case 'Never':
+        await config.rememberHhastWorkspace(workspace, 'untrusted');
+      case 'No':
+        return;
+    };
+  }
+
+  public async run(): Promise<void> {
+    let initializationOptions: InitializationOptions = {};
+    const lintMode = config.hhastLintMode;
+    if (lintMode) {
+      initializationOptions.lintMode = lintMode;
+    }
+
+    const hhast = new LanguageClient(
+      'HHAST',
+      { command: this.hhastPath, args: [...config.hhastArgs, '--mode', 'lsp', '--from', 'vscode-hack'] },
+      {
+        documentSelector: [{ language: 'hack', scheme: 'file' }],
+        initializationOptions: initializationOptions,
+        middleware: {
+          handleDiagnostics: this.handleDiagnostics,
+        },
+      },
+    );
+    this.context.subscriptions.push(hhast.start());
+  }
+
+  private handleDiagnostics(uri: vscode.Uri, diagnostics: vscode.Diagnostic[], next: HandleDiagnosticsSignature) {
+    next(uri, diagnostics.map(d => {
+      d.message = d.code + ': ' + d.message;
+      return d;
+    }));
+  }
+}

--- a/src/LSPHackTypeChecker.ts
+++ b/src/LSPHackTypeChecker.ts
@@ -1,0 +1,68 @@
+/** @file Integration with the Hack type checker via the LSP */
+
+import * as vscode from 'vscode';
+import { LanguageClient, HandleDiagnosticsSignature } from 'vscode-languageclient/lib/main';
+import * as config from './Config';
+import * as utils from './Utils';
+import * as hack from './types/hack';
+
+export class LSPHackTypeChecker {
+  private context: vscode.ExtensionContext;
+
+  constructor(context: vscode.ExtensionContext) {
+    this.context = context;
+  }
+
+  public async run(): Promise<void> {
+    const context = this.context;
+    const languageClient = new LanguageClient(
+      'Hack Language Server',
+      { command: config.hhClientCommand, args: [...config.hhClientArgs, 'lsp', '--from', 'vscode-hack'] },
+      {
+        documentSelector: [{ language: 'hack', scheme: 'file' }],
+        initializationOptions: { useTextEditAutocomplete: true },
+        uriConverters: { code2Protocol: utils.mapFromWorkspaceUri, protocol2Code: utils.mapToWorkspaceUri },
+        middleware: {
+          handleDiagnostics: this.handleDiagnostics,
+        }
+      },
+    );
+    context.subscriptions.push(languageClient.start());
+  }
+
+  private handleDiagnostics(uri: vscode.Uri, diagnostics: vscode.Diagnostic[], next: HandleDiagnosticsSignature) {
+    next(uri, diagnostics.map(d => {
+      // See https://github.com/facebook/hhvm/blob/028402226993d53d68e17125e0b7c8dd87ea6c17/hphp/hack/src/errors/errors.ml#L174
+      let kind: string;
+      switch (Math.floor((d.code as number) / 1000)) {
+        case 1:
+          kind = 'Parsing';
+          break;
+        case 2:
+          kind = 'Naming';
+          break;
+        case 3:
+          kind = 'NastCheck';
+          break;
+        case 4:
+          kind = 'Typing';
+          break;
+        case 5:
+          kind = 'Lint';
+          break;
+        case 8:
+          kind = 'Init';
+          break;
+        default:
+          kind = 'Other';
+          break;
+      }
+      d.message = kind + '[' + d.code + '] ' + d.message;
+      return d;
+    }));
+  }
+
+  public static isSupported(version: hack.Version): boolean {
+    return version.api_version >= 5;
+  }
+}

--- a/src/LegacyHackTypeChecker.ts
+++ b/src/LegacyHackTypeChecker.ts
@@ -1,19 +1,41 @@
 /**
- * @file VS Code diagnostics integration with Hack typechecker.
+ * @file VS Code diagnostics integration with Hack typechecker by executing
+ * `hh_client` each time
  */
 
 import * as vscode from 'vscode';
 import * as hh_client from './proxy';
 import * as utils from './Utils';
+import * as providers from './providers';
+import * as suppressions from './suppressions';
 
-export class HackTypeChecker {
+export class LegacyHackTypeChecker {
     private hhvmTypeDiag: vscode.DiagnosticCollection;
 
-    constructor(hhvmTypeDiag: vscode.DiagnosticCollection) {
+    constructor(context: vscode.ExtensionContext) {
+        // register language functionality providers
+        const HACK_MODE: vscode.DocumentFilter = { language: 'hack', scheme: 'file' };
+        context.subscriptions.push(vscode.languages.registerHoverProvider(HACK_MODE, new providers.HackHoverProvider()));
+        context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(HACK_MODE, new providers.HackDocumentSymbolProvider()));
+        context.subscriptions.push(vscode.languages.registerWorkspaceSymbolProvider(new providers.HackWorkspaceSymbolProvider()));
+        context.subscriptions.push(vscode.languages.registerDocumentHighlightProvider(HACK_MODE, new providers.HackDocumentHighlightProvider()));
+        context.subscriptions.push(vscode.languages.registerCompletionItemProvider(HACK_MODE, new providers.HackCompletionItemProvider(), '$', '>', ':', '\\'));
+        context.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(HACK_MODE, new providers.HackDocumentFormattingEditProvider()));
+        context.subscriptions.push(vscode.languages.registerReferenceProvider(HACK_MODE, new providers.HackReferenceProvider()));
+        context.subscriptions.push(vscode.languages.registerDefinitionProvider(HACK_MODE, new providers.HackDefinitionProvider()));
+        context.subscriptions.push(vscode.languages.registerCodeActionsProvider(HACK_MODE, new providers.HackCodeActionProvider()));
+
+        // add command to add an error suppression comment
+        context.subscriptions.push(vscode.commands.registerCommand('hack.suppressError', suppressions.suppressError));
+
+        // create typechecker and run when workspace is first loaded and on every file save
+        const hhvmTypeDiag: vscode.DiagnosticCollection = vscode.languages.createDiagnosticCollection('hack_typecheck');
         this.hhvmTypeDiag = hhvmTypeDiag;
+        context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(() => { this.run(); }));
+        context.subscriptions.push(hhvmTypeDiag);
     }
 
-    public async run() {
+    public async run(): Promise<void> {
         const typecheckResult = await hh_client.check();
         this.hhvmTypeDiag.clear();
 

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -16,8 +16,8 @@ import * as child_process from 'child_process';
 import * as net from 'net';
 import * as os from 'os';
 import { Writable } from 'stream';
-import { OutputEvent } from 'vscode-debugadapter';
-import { DebugProtocol } from 'vscode-debugprotocol';
+import { OutputEvent } from 'vscode-debugadapter/lib/main';
+import { DebugProtocol } from 'vscode-debugprotocol/lib/debugProtocol';
 
 const TWO_CRLF = '\r\n\r\n';
 const CONTENT_LENGTH_PATTERN = new RegExp('Content-Length: (\\d+)');

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,14 +3,13 @@
  */
 
 import * as vscode from 'vscode';
-import { LanguageClient } from 'vscode-languageclient';
 import * as config from './Config';
 import { HackCoverageChecker } from './coveragechecker';
-import * as providers from './providers';
 import * as hh_client from './proxy';
-import * as suppressions from './suppressions';
-import { HackTypeChecker } from './typechecker';
-import * as utils from './Utils';
+import { LegacyHackTypeChecker } from './LegacyHackTypeChecker';
+import { LSPHackTypeChecker } from './LSPHackTypeChecker';
+import { LSPHHASTLint } from './LSPHHASTLint';
+
 
 export async function activate(context: vscode.ExtensionContext) {
 
@@ -23,45 +22,23 @@ export async function activate(context: vscode.ExtensionContext) {
         return;
     }
 
+    let services: Promise<void>[] = [];
+
     // create coverage checker and run on file open & save, if enabled in settings
     if (config.enableCoverageCheck) {
-        await new HackCoverageChecker().start(context);
+        services.push(new HackCoverageChecker().start(context));
     }
 
-    if (version.api_version >= 5 && config.useLanguageServer) {
-        const languageClient = new LanguageClient(
-            'Hack Language Server',
-            { command: config.hhClientCommand, args: [...config.hhClientArgs, 'lsp', '--from', 'vscode-hack'] },
-            {
-                documentSelector: [{ language: 'hack', scheme: 'file' }],
-                uriConverters: { code2Protocol: utils.mapFromWorkspaceUri, protocol2Code: utils.mapToWorkspaceUri },
-                initializationOptions: { useTextEditAutocomplete: true }
-            });
-        context.subscriptions.push(languageClient.start());
-        return;
+    services.push(LSPHHASTLint.startIfConfiguredAndEnabled(context));
+
+    if (LSPHackTypeChecker.isSupported(version) && config.useLanguageServer) {
+        services.push((new LSPHackTypeChecker(context)).run());
+    } else {
+        services.push((new LegacyHackTypeChecker(context)).run());
     }
 
-    // register language functionality providers
-    const HACK_MODE: vscode.DocumentFilter = { language: 'hack', scheme: 'file' };
-    context.subscriptions.push(vscode.languages.registerHoverProvider(HACK_MODE, new providers.HackHoverProvider()));
-    context.subscriptions.push(vscode.languages.registerDocumentSymbolProvider(HACK_MODE, new providers.HackDocumentSymbolProvider()));
-    context.subscriptions.push(vscode.languages.registerWorkspaceSymbolProvider(new providers.HackWorkspaceSymbolProvider()));
-    context.subscriptions.push(vscode.languages.registerDocumentHighlightProvider(HACK_MODE, new providers.HackDocumentHighlightProvider()));
-    context.subscriptions.push(vscode.languages.registerCompletionItemProvider(HACK_MODE, new providers.HackCompletionItemProvider(), '$', '>', ':', '\\'));
-    context.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(HACK_MODE, new providers.HackDocumentFormattingEditProvider()));
-    context.subscriptions.push(vscode.languages.registerReferenceProvider(HACK_MODE, new providers.HackReferenceProvider()));
-    context.subscriptions.push(vscode.languages.registerDefinitionProvider(HACK_MODE, new providers.HackDefinitionProvider()));
-    context.subscriptions.push(vscode.languages.registerCodeActionsProvider(HACK_MODE, new providers.HackCodeActionProvider()));
+    await Promise.all(services);
 
-    // add command to add an error suppression comment
-    context.subscriptions.push(vscode.commands.registerCommand('hack.suppressError', suppressions.suppressError));
-
-    // create typechecker and run when workspace is first loaded and on every file save
-    const hhvmTypeDiag: vscode.DiagnosticCollection = vscode.languages.createDiagnosticCollection('hack_typecheck');
-    const typechecker = new HackTypeChecker(hhvmTypeDiag);
-    context.subscriptions.push(vscode.workspace.onDidSaveTextDocument(() => { typechecker.run(); }));
-    context.subscriptions.push(hhvmTypeDiag);
-    await typechecker.run();
 }
 
 export function deactivate() {


### PR DESCRIPTION
These were originally separate diffs, but given they each ended up
rewriting a substantial portion of the code in the other diffs anyway
and it's short overall, keeping it as one. This PR

- Adds support for HHAST
  - user/workspace setting for globally enabling/disabling. Off by
  default.
  - user prompting for whether to enable it per-repo
  - that setting is remembered in user settings. workspace settings are
  ignored to avoid allowing project authors to enable prompt-less
  arbitrary code execution when vscode is opened
- Add error codes to error messages:
  - HHAST: `DontAwaitInALoop: blah blah blah`
  - Hack: `Parsing[1002]: blah blah blah`
- Refactor:
  - there's now 4 services. Start them more consistently and move stuff
    out from index.ts
  - rename typechecker to LegacyHackTypeChecker